### PR TITLE
Necessary tweaks to simplify the tarball creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log*
 node_modules/
 yarn-error.log
+*.tgz

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "semver": "^7.5.2"
-  }
+  },
+  "files": [
+    "dist/",
+    "locales/"
+  ]
 }


### PR DESCRIPTION
# Problem

NPM runs build scripts of packages hosted on GitHub, which increases the installation time and is error-prone. However, NPM ignores the build scripts when installing a tarball package, even hosted on GitHub.

# Changes 

This patch makes necessary tweaks to simplify the tarball creation.